### PR TITLE
アップロード済みの画像をキャラデータに設定できるようにしました

### DIFF
--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -45,22 +45,16 @@ class CharacterController extends Controller
     }
     
     public function createForm(){
-        return view('lists.characters.create');
+        $gallery = Image::latest()->get();
+        return view('lists.characters.create', [
+            'images' => $gallery,
+        ]);
     }
     
     public function create(CreateCharacter $request){
         $chara = new Character();
         $chara->name = $request->name;
-        
-        $file_name = $request->file('cimage')->getClientOriginalName();
-        $request->file('cimage')->storeAs(ImageController::getImagePath(), $file_name, 'public');
-        
-        $image = new Image();
-        $image->name = $file_name;
-        $image->path = 'storage/'. ImageController::getImagePath() . '/' . $file_name;
-        Auth::user()->images()->save($image);
-        $chara->image_path = $image->path;
-        
+        $chara->image_path = $request->image;
         $chara->explain = $request->explain;
         $chara->descript = $request->descript;
         Auth::user()->characters()->save($chara);
@@ -71,12 +65,15 @@ class CharacterController extends Controller
     public function editForm(Character $chara){
         $user = Auth::user();
         $chara = $user->characters()->findOrFail($chara->id);
+        $gallery = Image::latest()->get();
         
         return view('lists.characters.edit', [
             'chara_id' => $chara->id,
             'chara_name' => $chara->name,
+            'chara_image' => $chara->image_path,
             'chara_explain' => $chara->explain,
             'chara_descript' => $chara->descript,
+            'images' => $gallery,
         ]);
     }
     
@@ -85,6 +82,7 @@ class CharacterController extends Controller
         $chara = $user->characters()->findOrFail($chara->id);
         
         $chara->name = $request->name;
+        $chara->image_path = $request->image;
         $chara->explain = $request->explain;
         $chara->descript = $request->descript;
         $chara->save();

--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -11,13 +11,13 @@ use Carbon\Carbon;
 class ImageController extends Controller
 {
     public static function getImagePath(){
-        return 'img/'. Auth::id();
+        return 'img/user_'. Auth::id();
     }
     
     public static function getImageName(Request $request){
         $original_name = $request->file('image')->getClientOriginalName();
         $image_at = Carbon::now();
-        return $image_at->format('Y/m/d_H-i-s') . '_' . $original_name;
+        return $image_at->format('Y-m-d_H-i-s') . '_' . $original_name;
     }
     
     public function index(){
@@ -28,11 +28,12 @@ class ImageController extends Controller
     }
     
     public function upload(Request $request){
+        $original_name = $request->file('image')->getClientOriginalName();
         $image_name = $this->getImageName($request);
         $request->file('image')->storeAs($this->getImagePath(), $image_name, 'public');
         
         $image = new Image();
-        $image->name = $image_name;
+        $image->name = $original_name;
         $image->path = 'storage/'. $this->getImagePath() . '/' . $image_name;
         Auth::user()->images()->save($image);
         return redirect()->route('img.gallery');

--- a/resources/views/components/modal-museum.blade.php
+++ b/resources/views/components/modal-museum.blade.php
@@ -1,0 +1,78 @@
+@props([
+    'name',
+    'show' => false,
+    'maxWidth' => '2xl'
+])
+
+@php
+$maxWidth = [
+    'sm' => 'sm:max-w-sm',
+    'md' => 'sm:max-w-md',
+    'lg' => 'sm:max-w-lg',
+    'xl' => 'sm:max-w-xl',
+    '2xl' => 'sm:max-w-2xl',
+][$maxWidth];
+@endphp
+
+<div
+    x-data="{
+        show: @js($show),
+        focusables() {
+            // All focusable element types...
+            let selector = 'a, button, input:not([type=\'hidden\']), textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
+            return [...$el.querySelectorAll(selector)]
+                // All non-disabled elements...
+                .filter(el => ! el.hasAttribute('disabled'))
+        },
+        firstFocusable() { return this.focusables()[0] },
+        lastFocusable() { return this.focusables().slice(-1)[0] },
+        nextFocusable() { return this.focusables()[this.nextFocusableIndex()] || this.firstFocusable() },
+        prevFocusable() { return this.focusables()[this.prevFocusableIndex()] || this.lastFocusable() },
+        nextFocusableIndex() { return (this.focusables().indexOf(document.activeElement) + 1) % (this.focusables().length + 1) },
+        prevFocusableIndex() { return Math.max(0, this.focusables().indexOf(document.activeElement)) -1 },
+    }"
+    x-init="$watch('show', value => {
+        if (value) {
+            document.body.classList.add('overflow-y-hidden');
+            {{ $attributes->has('focusable') ? 'setTimeout(() => firstFocusable().focus(), 100)' : '' }}
+        } else {
+            document.body.classList.remove('overflow-y-hidden');
+        }
+    })"
+    x-on:open-modal.window="$event.detail == '{{ $name }}' ? show = true : null"
+    x-on:close-modal.window="$event.detail == '{{ $name }}' ? show = false : null"
+    x-on:close.stop="show = false"
+    x-on:keydown.escape.window="show = false"
+    x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
+    x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
+    x-show="show"
+    class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
+    style="display: {{ $show ? 'block' : 'none' }};"
+>
+    <div
+        x-show="show"
+        class="fixed inset-0 transform transition-all"
+        x-on:click="show = false"
+        x-transition:enter="ease-out duration-300"
+        x-transition:enter-start="opacity-0"
+        x-transition:enter-end="opacity-100"
+        x-transition:leave="ease-in duration-200"
+        x-transition:leave-start="opacity-100"
+        x-transition:leave-end="opacity-0"
+    >
+        <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
+    </div>
+
+    <div
+        x-show="show"
+        class="mb-6 bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
+        x-transition:enter="ease-out duration-300"
+        x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+        x-transition:leave="ease-in duration-200"
+        x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+        x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+    >
+        {{ $slot }}
+    </div>
+</div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -15,7 +15,9 @@
                 <div class="m-4 p-4 border border-black">
                     <h3 class="text-2xl border-b-2 border-black">{{$character->name}}</h3>
                     <div class="flex">
+                        @if($character->image_path !== null)
                         <img src="{{ asset($character->image_path) }}" class="m-4 w-full max-w-44 h-full max-h-44">
+                        @endif
                         <p class="my-4">{{$character->explain}}</p>
                     </div>
                     <a href="{{route('charas.detail', ['chara' => $character->id])}}" class="block text-sky-800 mx-4 text-right">more</a>

--- a/resources/views/gallery/index.blade.php
+++ b/resources/views/gallery/index.blade.php
@@ -6,25 +6,10 @@
             </h2>
         </div>
     </x-slot>
-    
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="m-4">
-                    <form method="post" action="{{ route('img.upload') }}" enctype="multipart/form-data">
-                        @csrf
-                        <input type="file" name="image">
-                        <button>アップロード</button>
-                    </form>
-                </div>
-            </div>
-            <div class="my-4">
-                <div class="flex">
-                    @foreach($images as $image)
-                    <img src="{{ asset($image->path) }}" class="mx-4 my-8 w-full max-w-44 h-full max-h-44">
-                    @endforeach
-                </div>
-            </div>
+            @include('gallery.upload')
+            @include('gallery.view')
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/gallery/upload.blade.php
+++ b/resources/views/gallery/upload.blade.php
@@ -1,0 +1,11 @@
+<section>
+    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+        <div class="m-4">
+            <form method="post" action="{{ route('img.upload') }}" enctype="multipart/form-data">
+                @csrf
+                <input type="file" name="image" accept="image/*">
+                <button>アップロード</button>
+            </form>
+        </div>
+    </div>
+</section>

--- a/resources/views/gallery/view.blade.php
+++ b/resources/views/gallery/view.blade.php
@@ -1,0 +1,11 @@
+<section>
+    <div class="my-4">
+        <div class="flex flex-wrap -m-4">
+            @foreach($images as $image)
+            <button class="uploaded_img" type="button" value="{{ $image->path }}">
+                <img src="{{ asset($image->path) }}" class="m-4 w-full min-w-44 max-w-44 h-full min-h-44 max-h-44">
+            </button>
+            @endforeach
+        </div>
+    </div>
+</section>

--- a/resources/views/lists/characters/create.blade.php
+++ b/resources/views/lists/characters/create.blade.php
@@ -36,7 +36,8 @@
                 <tr>
                     <th class="w-1/6">画像</th>
                     <td>
-                        <input type="file" name="cimage">
+                        <input type="text" name="image" id="selectedImage" class="border-none w-full" value="" readonly>
+                        <button type="button" x-data="" x-on:click.prevent="$dispatch('open-modal', 'image-uploader')">選択</button>
                     </td>
                 </tr>
             </table>
@@ -44,6 +45,25 @@
             <button type="submit" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">作成</button>
             <button type="button" onclick="history.back()" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">戻る</button>
         </form>
+        <x-modal-museum name="image-uploader">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="flex justify-between">
+                    <h2 class="text-lg font-medium text-gray-900 my-4">画像を選択してください。</h2>
+                    <button type="button" x-on:click="$dispatch('close')">閉じる</button>
+                </div>
+                <input type="text" id="selectedImageFlag" class="border-none w-full" value="" readonly>
+                @include('gallery.view')
+            </div>
+        </x-modal-museum>
     </div>
     <script src="{{ asset('/js/resize.js') }}"></script>
+    <script>
+        var imagePath = document.getElementById('selectedImage');
+        var imageFlag = document.getElementById('selectedImageFlag');
+        $('.uploaded_img').on('click', function(event) {
+            var selected = $(event.currentTarget).val();
+            imagePath.value = selected;
+            imageFlag.value = selected;
+        });
+    </script>
 </x-app-layout>

--- a/resources/views/lists/characters/detail.blade.php
+++ b/resources/views/lists/characters/detail.blade.php
@@ -12,7 +12,9 @@
                 <a href="{{ route('users.index', ['user' => $chara->user->id]) }}" class="text-sky-800">{{ $chara_user }}</a>
             </div>
             <div class="flex">
+                @if($chara_image !== null)
                 <img src="{{ asset($chara_image) }}" class="m-4 w-full max-w-44 h-full max-h-44">
+                @endif
                 <p class="my-4">{{$chara_explain}}</p>
             </div>
             <p class="mx-4">{{$chara_descript}}</p>

--- a/resources/views/lists/characters/edit.blade.php
+++ b/resources/views/lists/characters/edit.blade.php
@@ -33,11 +33,37 @@
                         <textarea type="text" name="descript" class="retextarea w-full h-full">{{ old('descript') ?? $chara_descript }}</textarea>
                     </td>
                 </tr>
+                <tr>
+                    <th class="w-1/6">画像</th>
+                    <td>
+                        <input type="text" name="image" id="selectedImage" class="border-none w-full" value="" readonly>
+                        <button type="button" x-data="" x-on:click.prevent="$dispatch('open-modal', 'image-uploader')">選択</button>
+                    </td>
+                </tr>
             </table>
             @csrf
             <button type="submit" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">編集完了</button>
             <button type="button" onclick="history.back();" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">戻る</button>
         </form>
+        <x-modal-museum name="image-uploader">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="flex justify-between">
+                    <h2 class="text-lg font-medium text-gray-900 my-4">画像を選択してください。</h2>
+                    <button type="button" x-on:click="$dispatch('close')">閉じる</button>
+                </div>
+                <input type="text" id="selectedImageFlag" class="border-none w-full" value="" readonly>
+                @include('gallery.view')
+            </div>
+        </x-modal-museum>
     </div>
     <script src="{{ asset('/js/resize.js') }}"></script>
+    <script>
+        var imagePath = document.getElementById('selectedImage');
+        var imageFlag = document.getElementById('selectedImageFlag');
+        $('.uploaded_img').on('click', function(event) {
+            var selected = $(event.currentTarget).val();
+            imagePath.value = selected;
+            imageFlag.value = selected;
+        });
+    </script>
 </x-app-layout>

--- a/resources/views/scripts/followSystem.blade.php
+++ b/resources/views/scripts/followSystem.blade.php
@@ -14,7 +14,6 @@ $('.follow').on('click', function(event) {
         },
     })
     .done(function(res) {
-        console.log(res);
         follow_user.toggleClass('bg-sky-400 bg-red-400');
         if(follow_user.text() === 'follow'){
             follow_user.text('unfollow');


### PR DESCRIPTION
新規作成画面及び編集画面からアップロード済みの画像を選択し、その親のボタンに代入されたパスをキャラクターデータの画像パスカラムに入力する形で機能実装いたしました。また画像が設定されていないキャラクターはダッシュボード画面や各キャラクター画面に画像が表示されないよう変更いたしました。