### PR TITLE
キャラクター作成・編集の確認画面実装

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -15,7 +15,7 @@ class ImageController extends Controller
     }
     
     public static function getImageName(Request $request){
-        $original_name = $request->file('uploaded-image')->getClientOriginalName();
+        $original_name = $request->file('uploaded_image')->getClientOriginalName();
         $image_at = Carbon::now();
         return $image_at->format('Y-m-d_H-i-s') . '_' . $original_name;
     }
@@ -28,10 +28,10 @@ class ImageController extends Controller
     }
     
     public function upload(Request $request){
-        $original_name = $request->file('uploaded-image')->getClientOriginalName();
         $image_name = $this->getImageName($request);
-        $request->file('uploaded-image')->storeAs($this->getImagePath(), $image_name, 'public');
+        $request->file('uploaded_image')->storeAs($this->getImagePath(), $image_name, 'public');
         
+        $original_name = $request->file('uploaded_image')->getClientOriginalName();
         $image = new Image();
         $image->name = $original_name;
         $image->path = 'storage/'. $this->getImagePath() . '/' . $image_name;

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -16,7 +16,7 @@
                     <h3 class="text-2xl border-b-2 border-black">{{$character->name}}</h3>
                     <div class="flex">
                         @if($character->image_path !== null)
-                        <img src="{{ asset($character->image_path) }}" class="m-4 ml-0 w-full max-w-44 h-full max-h-44">
+                        <img src="{{ asset($character->image_path) }}" class="m-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
                         @endif
                         <p class="my-4">{{$character->explain}}</p>
                     </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -14,11 +14,11 @@
                 @foreach($characters as $character)
                 <div class="m-4 p-4 border border-black">
                     <h3 class="text-2xl border-b-2 border-black">{{$character->name}}</h3>
-                    <div class="flex">
+                    <div class="flex my-4">
                         @if($character->image_path !== null)
-                        <img src="{{ asset($character->image_path) }}" class="m-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
+                        <img src="{{ asset($character->image_path) }}" class="mx-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
                         @endif
-                        <p class="my-4">{{$character->explain}}</p>
+                        <p>{{$character->explain}}</p>
                     </div>
                     <a href="{{route('charas.detail', ['chara' => $character->id])}}" class="block text-sky-800 mx-4 text-right">more</a>
                 </div>

--- a/resources/views/gallery/upload.blade.php
+++ b/resources/views/gallery/upload.blade.php
@@ -3,7 +3,7 @@
         <div class="m-4">
             <form method="post" action="{{ route('img.upload') }}" enctype="multipart/form-data">
                 @csrf
-                <input type="file" name="uploaded-image" accept="image/*">
+                <input type="file" name="uploaded_image" accept="image/*">
                 <button>アップロード</button>
             </form>
         </div>

--- a/resources/views/lists/characters/create.blade.php
+++ b/resources/views/lists/characters/create.blade.php
@@ -37,7 +37,7 @@
                     <th class="w-1/6">画像</th>
                     <td>
                         <input type="radio" name="i-radio" value="upload">
-                        <input type="file" name="uploaded-image" id="uploaded_image" accept="image/*">
+                        <input type="file" name="uploaded_image" id="uploaded_image" accept="image/*">
                         <p class="text-center">または</p>
                         <input type="radio" name="i-radio" value="select">
                         <input type="text" name="selected_image" id="selected_image" class="w-full max-w-[90%] px-0" value="" readonly>

--- a/resources/views/lists/characters/createConfirm.blade.php
+++ b/resources/views/lists/characters/createConfirm.blade.php
@@ -1,37 +1,34 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __($chara_name. ' 削除') }}
+            {{ __($chara['name']. ' の作成確認') }}
         </h2>
     </x-slot>
     
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-        <h2 class="text-red-500 text-xl my-3">削除したデータは元に戻りません。よろしいでしょうか。</h2>
-        <form method="post" action="{{ route('charas.delete', ['chara' => $chara_id]) }}">
+        <form method="post" action="{{ route('charas.createConfirm') }}">
             <table class="bar my-3 bg-white w-full">
                 <tr>
                     <th class="w-1/12 bg-yellow-300">キャラクター名</th>
-                    <td class="border-l border-black">{{ $chara_name }}</td>
+                    <td class="border-l border-black">{{ $chara['name'] }}</td>
                 </tr>
                 <tr class="border-t border-black">
                     <th class="w-1/12 bg-yellow-300">画像</th>
                     <td class="border-l border-black">
-                        @if($chara_image !== null)
-                        <img src="{{ asset($chara_image)}}" class="m-2 w-full max-w-44 h-full max-h-44">
-                        @endif
+                        <img src="{{ asset($image_path) }}" class="m-4 w-full max-w-44 h-full max-h-44">
                     </td>
                 </tr>
                 <tr class="border-t border-black">
                     <th class="w-1/12 bg-yellow-300">説明</th>
-                    <td class="border-l border-black">{{ $chara_explain }}</td>
+                    <td class="border-l border-black">{{ $chara['explain'] }}</td>
                 </tr>
                 <tr class="border-t border-black">
                     <th class="w-1/12 bg-yellow-300">もっと詳しく</th>
-                    <td class="border-l border-black">{{ $chara_descript }}</td>
+                    <td class="border-l border-black">{{ $chara['descript'] }}</td>
                 </tr>
             </table>
             @csrf
-            <button type="submit" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">削除</button>
+            <button type="submit" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">作成</button>
             <button type="button" onclick="history.back();" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">戻る</button>
         </form>
     </div>

--- a/resources/views/lists/characters/detail.blade.php
+++ b/resources/views/lists/characters/detail.blade.php
@@ -11,15 +11,15 @@
                 <h3>{{$chara_name}}</h3>
                 <a href="{{ route('users.index', ['user' => $chara->user->id]) }}" class="text-sky-800">{{ $chara_user }}</a>
             </div>
-            <div class="flex">
+            <div class="flex my-4">
                 @if($chara_image !== null)
-                <img src="{{ asset($chara_image) }}" class="m-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
+                <img src="{{ asset($chara_image) }}" class="mx-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
                 @endif
-                <p class="my-4">{{$chara_explain}}</p>
+                <p>{{$chara_explain}}</p>
             </div>
-            <p class="mx-4">{{$chara_descript}}</p>
+            <p>{{$chara_descript}}</p>
         </div>
-        <div class="toolbox">
+        <div class="toolbox mx-4">
             <a href="{{ route('charas.index') }}" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">一覧表に戻る</a>
             @auth
             <a href="{{ route('charas.create') }}" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">新規作成</a>

--- a/resources/views/lists/characters/detail.blade.php
+++ b/resources/views/lists/characters/detail.blade.php
@@ -13,7 +13,7 @@
             </div>
             <div class="flex">
                 @if($chara_image !== null)
-                <img src="{{ asset($chara_image) }}" class="m-4 ml-0 w-full max-w-44 h-full max-h-44">
+                <img src="{{ asset($chara_image) }}" class="m-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
                 @endif
                 <p class="my-4">{{$chara_explain}}</p>
             </div>

--- a/resources/views/lists/characters/edit.blade.php
+++ b/resources/views/lists/characters/edit.blade.php
@@ -37,7 +37,7 @@
                     <th class="w-1/6">画像</th>
                     <td>
                         <input type="radio" name="i-radio" value="upload">
-                        <input type="file" name="uploaded-image" id="uploaded_image" accept="image/*">
+                        <input type="file" name="uploaded_image" id="uploaded_image" accept="image/*">
                         <p class="text-center">または</p>
                         <input type="radio" name="i-radio" value="select" {{(old('$selected_image') != $chara_image) ? 'checked' : ''}}>
                         <input type="text" name="selected_image" id="selected_image" class="w-full max-w-[90%] px-0" value="{{ old('selected_image') ?? $chara_image }}" readonly>

--- a/resources/views/lists/characters/editConfirm.blade.php
+++ b/resources/views/lists/characters/editConfirm.blade.php
@@ -1,12 +1,12 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __($chara['name']. ' の作成確認') }}
+            {{ __($chara['name']. ' の編集確認') }}
         </h2>
     </x-slot>
     
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-        <form method="post" action="{{ route('charas.createConfirm') }}">
+        <form method="post" action="{{ route('charas.editConfirm', [$chara_id]) }}">
             <table class="bar my-3 bg-white w-full">
                 <tr>
                     <th class="w-1/12 bg-yellow-300">キャラクター名</th>
@@ -30,7 +30,7 @@
                 </tr>
             </table>
             @csrf
-            <button type="submit" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">作成</button>
+            <button type="submit" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">更新</button>
             <button type="button" onclick="history.back();" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">戻る</button>
         </form>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,8 @@ Route::group(['middleware' => 'auth'], function() {
     
     Route::get('/charaList/create', [CharacterController::class, 'createForm'])->name('charas.create');
     Route::post('/charaList/create', [CharacterController::class, 'create']);
+    Route::get('/charaList/create/confirm', [CharacterController::class, 'createConfirm'])->name('charas.createConfirm');
+    Route::post('/charaList/create/confirm', [CharacterController::class, 'createSend']);
     
     Route::get('/users/{user}/followList', [FollowUserController::class, 'followIndex'])->name('users.followIndex');
     Route::get('/users/{user}/followerList', [FollowUserController::class, 'followerIndex'])->name('users.followerIndex');
@@ -38,6 +40,8 @@ Route::group(['middleware' => 'auth'], function() {
     Route::group(['middleware' => 'can:view,chara'], function() {
         Route::get('/charaList/{chara}/edit', [CharacterController::class, 'editForm'])->name('charas.edit');
         Route::post('/charaList/{chara}/edit', [CharacterController::class, 'edit']);
+        Route::get('/charaList/{chara}/edit/confirm', [CharacterController::class, 'editConfirm'])->name('charas.editConfirm');
+        Route::post('/charaList/{chara}/edit/confirm', [CharacterController::class, 'editSend']);
         
         Route::get('/charaList/{chara}/delete', [CharacterController::class, 'deleteForm'])->name('charas.delete');
         Route::post('/charaList/{chara}/delete', [CharacterController::class, 'delete']);


### PR DESCRIPTION
キャラクター作成・編集時に、すぐにアップロードせず確認画面に遷移し、確認後「作成」または「更新」ボタンをクリックすることでキャラクターを登録・更新するように改修いたしました。