### PR TITLE
確認画面への直接アクセスを防止

### DIFF
--- a/app/Http/Requests/ImageRequest.php
+++ b/app/Http/Requests/ImageRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/resources/views/lists/characters/create.blade.php
+++ b/resources/views/lists/characters/create.blade.php
@@ -37,7 +37,7 @@
                     <th class="w-1/6">画像</th>
                     <td>
                         <input type="radio" name="i-radio" value="upload">
-                        <input type="file" name="uploaded_image" id="uploaded_image" accept="image/*">
+                        <input type="file" name="uploaded_image" id="uploaded_image" accept="image/png, image/jpeg">
                         <p class="text-center">または</p>
                         <input type="radio" name="i-radio" value="select">
                         <input type="text" name="selected_image" id="selected_image" class="w-full max-w-[90%] px-0" value="" readonly>

--- a/resources/views/lists/characters/detail.blade.php
+++ b/resources/views/lists/characters/detail.blade.php
@@ -6,6 +6,7 @@
     </x-slot>
     
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <p class="m-4">{{ session('message') }}</p>
         <div class="bg-white m-4 p-4 border border-black">
             <div class="flex text-2xl border-b-2 border-black justify-between">
                 <h3>{{$chara_name}}</h3>

--- a/resources/views/lists/characters/edit.blade.php
+++ b/resources/views/lists/characters/edit.blade.php
@@ -37,9 +37,9 @@
                     <th class="w-1/6">画像</th>
                     <td>
                         <input type="radio" name="i-radio" value="upload">
-                        <input type="file" name="uploaded_image" id="uploaded_image" accept="image/*">
+                        <input type="file" name="uploaded_image" id="uploaded_image" accept="image/png, image/jpeg">
                         <p class="text-center">または</p>
-                        <input type="radio" name="i-radio" value="select" {{(old('$selected_image') != $chara_image) ? 'checked' : ''}}>
+                        <input type="radio" name="i-radio" value="select" {{ old('$selected_image') == $chara_image ? '' : 'checked' }}>
                         <input type="text" name="selected_image" id="selected_image" class="w-full max-w-[90%] px-0" value="{{ old('selected_image') ?? $chara_image }}" readonly>
                         <button type="button" id="selecter_open" x-data="" x-on:click.prevent="$dispatch('open-modal', 'image-uploader')" class="bg-blue-500 disabled:bg-gray-400 text-white px-2">選択</button>
                     </td>


### PR DESCRIPTION
URLを直接入力して確認画面にアクセスした場合、トークンを保持していなければ新規作成または編集画面に遷移する機能を実装いたしました。編集確認画面はそれに加えて、編集したキャラクターのIDが一致していない場合、編集画面に遷移する機能も実装しております。
また、画像のアップロードに関するバリデーションも実装し、jpeg・pngファイル以外はアップロードできないよう改修いたしました。