### PR TITLE
CharacterImage to ImagePage

### DIFF
--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -38,12 +38,6 @@ class CharacterController extends Controller
         
         return view('characters.detail', [
             'chara' => $chara,
-            'chara_id' => $chara->id,
-            'chara_name' => $chara->name,
-            'chara_image' => $chara->image_path,
-            'chara_explain' => $chara->explain,
-            'chara_descript' => $chara->descript,
-            'chara_user' => $chara->user->name,
         ]);
     }
     
@@ -120,13 +114,14 @@ class CharacterController extends Controller
             $image->name = $info_name;
             $image->path = 'storage/' . $new_image_path;
             Auth::user()->images()->save($image);
-            $chara->image_path = $image->path;
+            $chara->image_id = $image->id;
             $request->session()->forget("image_session");
             $request->session()->forget("image_name_session");
             $request->session()->forget("image_original_session");
         }
         else if ($image_path_session !== null){
-            $chara->image_path = $image_path_session;
+            $image_id = Image::find($image_path_session)->id;
+            $chara->image_id = $image_id;
             $request->session()->forget("image_path_session");
         }
         
@@ -146,11 +141,7 @@ class CharacterController extends Controller
         $gallery = Image::orderBy('id', 'DESC')->paginate(15);
         
         return view('characters.edit', [
-            'chara_id' => $chara->id,
-            'chara_name' => $chara->name,
-            'chara_image' => $chara->image_path,
-            'chara_explain' => $chara->explain,
-            'chara_descript' => $chara->descript,
+            'chara' => $chara,
             'images' => $gallery,
         ]);
     }
@@ -242,17 +233,18 @@ class CharacterController extends Controller
             $image->name = $info_name;
             $image->path = 'storage/' . $new_image_path;
             Auth::user()->images()->save($image);
-            $chara->image_path = $image->path;
+            $chara->image_id = $image->id;
             $request->session()->forget("image_session");
             $request->session()->forget("image_name_session");
             $request->session()->forget("image_original_session");
         }
         else if ($image_path_session !== null){
-            $chara->image_path = $image_path_session;
+            $image_id = Image::find($image_path_session)->id;
+            $chara->image_id = $image_id;
             $request->session()->forget("image_path_session");
         }
         else{
-            $chara->image_path = null;
+            $chara->image_id = null;
         }
         
         $chara->name = $chara_session['name'];
@@ -270,11 +262,7 @@ class CharacterController extends Controller
         $chara = $user->characters()->findOrFail($chara->id);
         
         return view('characters.delete', [
-            'chara_id' => $chara->id,
-            'chara_name' => $chara->name,
-            'chara_image' => $chara->image_path,
-            'chara_explain' => $chara->explain,
-            'chara_descript' => $chara->descript,
+            'chara' => $chara,
         ]);
     }
     

--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -49,7 +49,7 @@ class CharacterController extends Controller
     }
     
     public function create(CreateCharacter $request){
-        $request->session()->forget(["chara_session", "image_session", "image_path_session", "image_name_session", "image_original_session"]);
+        $request->session()->forget(["chara_session", "image_session", "image_id_session", "image_name_session", "image_original_session"]);
         $chara_session = $request->only($this->chara_input);
         
         $validated = $request->validate([
@@ -66,8 +66,8 @@ class CharacterController extends Controller
             $request->session()->put("image_original_session", $original_name);
         }
         else if ($request->selected_image !== null){
-            $getpath = $request->selected_image;
-            $request->session()->put("image_path_session", $getpath);
+            $getid = $request->selected_image;
+            $request->session()->put("image_id_session", $getid);
         }
         $request->session()->put("chara_session", $chara_session);
         
@@ -84,8 +84,8 @@ class CharacterController extends Controller
         if ($request->session()->get("image_session") !== null){
             $image_session = $request->session()->get("image_session");
         }
-        else if ($request->session()->get("image_path_session") !== null){
-            $image_session = $request->session()->get("image_path_session");
+        else if ($request->session()->get("image_id_session") !== null){
+            $image_session = Image::find($request->session()->get("image_id_session"))->path;
         }
         else{
             $image_session = null;
@@ -100,7 +100,7 @@ class CharacterController extends Controller
     public function createSend(Request $request){
         $chara_session = $request->session()->get("chara_session");
         $image_session = $request->session()->get("image_session");
-        $image_path_session = $request->session()->get("image_path_session");
+        $image_id_session = $request->session()->get("image_id_session");
         $image_name = $request->session()->get("image_name_session");
         $original_name = $request->session()->get("image_original_session");
         
@@ -119,10 +119,9 @@ class CharacterController extends Controller
             $request->session()->forget("image_name_session");
             $request->session()->forget("image_original_session");
         }
-        else if ($image_path_session !== null){
-            $image_id = Image::find($image_path_session)->id;
-            $chara->image_id = $image_id;
-            $request->session()->forget("image_path_session");
+        else if ($image_id_session !== null){
+            $chara->image_id = $image_id_session;
+            $request->session()->forget("image_id_session");
         }
         
         $chara->name = $chara_session['name'];
@@ -150,7 +149,7 @@ class CharacterController extends Controller
         $user = Auth::user();
         $chara = $user->characters()->findOrFail($chara->id);
         
-        $request->session()->forget(["chara_session", "image_session", "image_path_session", "image_name_session", "image_original_session"]);
+        $request->session()->forget(["chara_session", "image_session", "image_id_session", "image_name_session", "image_original_session"]);
         $chara_session = $request->only($this->chara_input);
         
         $validated = $request->validate([
@@ -167,8 +166,8 @@ class CharacterController extends Controller
             $request->session()->put("image_original_session", $original_name);
         }
         else if ($request->selected_image !== null){
-            $getpath = $request->selected_image;
-            $request->session()->put("image_path_session", $getpath);
+            $getid = $request->selected_image;
+            $request->session()->put("image_id_session", $getid);
         }
         $request->session()->put("chara_session", $chara_session);
         
@@ -197,8 +196,8 @@ class CharacterController extends Controller
         if ($request->session()->get("image_session") !== null){
             $image_session = $request->session()->get("image_session");
         }
-        else if ($request->session()->get("image_path_session") !== null){
-            $image_session = $request->session()->get("image_path_session");
+        else if ($request->session()->get("image_id_session") !== null){
+            $image_session = Image::find($request->session()->get("image_id_session"))->path;
         }
         else{
             $image_session = null;
@@ -221,7 +220,7 @@ class CharacterController extends Controller
         
         $chara_session = $request->session()->get("chara_session");
         $image_session = $request->session()->get("image_session");
-        $image_path_session = $request->session()->get("image_path_session");
+        $image_id_session = $request->session()->get("image_id_session");
         $image_name = $request->session()->get("image_name_session");
         $original_name = $request->session()->get("image_original_session");
         
@@ -238,10 +237,9 @@ class CharacterController extends Controller
             $request->session()->forget("image_name_session");
             $request->session()->forget("image_original_session");
         }
-        else if ($image_path_session !== null){
-            $image_id = Image::find($image_path_session)->id;
-            $chara->image_id = $image_id;
-            $request->session()->forget("image_path_session");
+        else if ($image_id_session !== null){
+            $chara->image_id = $image_id_session;
+            $request->session()->forget("image_id_session");
         }
         else{
             $chara->image_id = null;

--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Image;
 use App\Models\User;
+use App\Models\Character;
 use App\Http\Requests\ImageRequest;
 use Carbon\Carbon;
 
@@ -30,9 +31,11 @@ class ImageController extends Controller
     
     public function detail(Image $image){
         $image->findOrFail($image->id);
+        $charas = Character::where('image_id', [$image->id])->get();
         
         return view('gallery.detail', [
             'image' => $image,
+            'charas' => $charas,
         ]);
     }
     

--- a/database/migrations/2024_10_07_042447_create_characters_table.php
+++ b/database/migrations/2024_10_07_042447_create_characters_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('characters', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name', length:24);
-            $table->string('image_path')->nullable($value = true);
+            $table->foreignId('image_id')->nullable($value = true)->constrained();
             $table->string('explain')->nullable($value = true);
             $table->string('descript')->nullable($value = true);
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();

--- a/public/js/image_paste.js
+++ b/public/js/image_paste.js
@@ -1,8 +1,11 @@
-var image_selector = document.getElementById('selected_image');
+var image_id_box = document.getElementById('selected_image');
+var image_selector = document.getElementById('selected_image_path');
 var image_flag = document.getElementById('selected_image_flag');
 
-$('.uploaded_imagen').on('click', function(event) {
-    var selected = $(event.currentTarget).val();
+$('.uploaded_image_selector').on('click', function(event) {
+    var image_id = $(event.target).attr('id');
+    image_id_box.value = image_id;
+    var selected = $(event.target).attr('alt');
     image_selector.value = selected;
     image_flag.value = selected;
 });

--- a/resources/views/characters/create.blade.php
+++ b/resources/views/characters/create.blade.php
@@ -40,7 +40,8 @@
                         <input type="file" name="uploaded_image" id="uploaded_image" accept="image/png, image/jpeg">
                         <p class="text-center">または</p>
                         <input type="radio" name="i-radio" value="select">
-                        <input type="text" name="selected_image" id="selected_image" class="w-full max-w-[90%] px-0" value="" readonly>
+                        <input type="hidden" name="selected_image" id="selected_image">
+                        <input type="text" name="selected_image_path" id="selected_image_path" class="w-full max-w-[90%] px-0" value="" readonly>
                         <button type="button" id="selecter_open" x-data="" x-on:click.prevent="$dispatch('open-modal', 'image-uploader')" class="bg-blue-500 disabled:bg-gray-400 text-white px-2">選択</button>
                     </td>
                 </tr>

--- a/resources/views/characters/delete.blade.php
+++ b/resources/views/characters/delete.blade.php
@@ -1,33 +1,33 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __($chara_name. ' 削除') }}
+            {{ __($chara->name. 'を削除') }}
         </h2>
     </x-slot>
     
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
         <h2 class="text-red-500 text-xl my-3">削除したデータは元に戻りません。よろしいでしょうか。</h2>
-        <form method="post" action="{{ route('charas.delete', ['chara' => $chara_id]) }}">
+        <form method="post" action="{{ route('charas.delete', ['chara' => $chara->id]) }}">
             <table class="bar my-3 bg-white w-full">
                 <tr>
                     <th class="w-1/12 bg-yellow-300">キャラクター名</th>
-                    <td class="border-l border-black">{{ $chara_name }}</td>
+                    <td class="border-l border-black">{{ $chara->name }}</td>
                 </tr>
                 <tr class="border-t border-black">
                     <th class="w-1/12 bg-yellow-300">画像</th>
                     <td class="border-l border-black">
-                        @if($chara_image !== null)
-                        <img src="{{ asset($chara_image)}}" class="m-2 w-full max-w-44 h-full max-h-44">
+                        @if($chara->image !== null)
+                        <img src="{{ asset($chara->image->path)}}" class="m-2 w-full max-w-44 h-full max-h-44">
                         @endif
                     </td>
                 </tr>
                 <tr class="border-t border-black">
                     <th class="w-1/12 bg-yellow-300">説明</th>
-                    <td class="border-l border-black">{{ $chara_explain }}</td>
+                    <td class="border-l border-black">{{ $chara->explain }}</td>
                 </tr>
                 <tr class="border-t border-black">
                     <th class="w-1/12 bg-yellow-300">もっと詳しく</th>
-                    <td class="border-l border-black">{{ $chara_descript }}</td>
+                    <td class="border-l border-black">{{ $chara->descript }}</td>
                 </tr>
             </table>
             @csrf

--- a/resources/views/characters/detail.blade.php
+++ b/resources/views/characters/detail.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __($chara_name. ' 詳細情報') }}
+            {{ __($chara->name. ' 詳細情報') }}
         </h2>
     </x-slot>
     
@@ -9,24 +9,26 @@
         <p class="m-4">{{ session('message') }}</p>
         <div class="bg-white my-4 p-4 border border-black">
             <div class="flex text-2xl border-b-2 border-black justify-between">
-                <h3>{{$chara_name}}</h3>
-                <a href="{{ route('users.index', ['user' => $chara->user->id]) }}" class="text-sky-800">{{ $chara_user }}</a>
+                <h3>{{$chara->name}}</h3>
+                <a href="{{ route('users.index', ['user' => $chara->user->id]) }}" class="text-sky-800">{{ $chara->user->name }}</a>
             </div>
             <div class="flex my-4">
-                @if($chara_image !== null)
-                <img src="{{ asset($chara_image) }}" class="mx-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
+                @if($chara->image !== null)
+                <a href="{{ route('images.detail', ['image' => $chara->image->id]) }}" class="mx-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
+                    <img src="{{ asset($chara->image->path) }}" class="w-full h-full">
+                </a>
                 @endif
-                <p>{{$chara_explain}}</p>
+                <p>{{$chara->explain}}</p>
             </div>
-            <p>{{$chara_descript}}</p>
+            <p>{{$chara->descript}}</p>
         </div>
         <div class="toolbox">
             <a href="{{ route('charas.index') }}" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">一覧表に戻る</a>
             @auth
             <a href="{{ route('charas.create') }}" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">新規作成</a>
-            @if($chara->user_id === Auth::user()->id)
-            <a href="{{ route('charas.edit', ['chara' => $chara_id]) }}" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">このデータを編集</a>
-            <a href="{{ route('charas.delete', ['chara' => $chara_id]) }}" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">このデータを削除</a>
+            @if($chara->user->id === Auth::user()->id)
+            <a href="{{ route('charas.edit', ['chara' => $chara->id]) }}" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">このデータを編集</a>
+            <a href="{{ route('charas.delete', ['chara' => $chara->id]) }}" class="bg-white px-3 py-2 shadow-sm sm:rounded-lg">このデータを削除</a>
             @endif
             @endauth
         </div>

--- a/resources/views/characters/edit.blade.php
+++ b/resources/views/characters/edit.blade.php
@@ -40,7 +40,8 @@
                         <input type="file" name="uploaded_image" id="uploaded_image" accept="image/png, image/jpeg">
                         <p class="text-center">または</p>
                         <input type="radio" name="i-radio" value="select" {{ old('$selected_image') == $chara->image ? '' : 'checked' }}>
-                        <input type="text" name="selected_image" id="selected_image" class="w-full max-w-[90%] px-0" value="{{ old('selected_image') ?? $chara->image->path }}" readonly>
+                        <input type="hidden" name="selected_image" id="selected_image">
+                        <input type="text" name="selected_image_path" id="selected_image_path" class="w-full max-w-[90%] px-0" value="{{ old('selected_image') ?? $chara->image->name }}" readonly>
                         <button type="button" id="selecter_open" x-data="" x-on:click.prevent="$dispatch('open-modal', 'image-uploader')" class="bg-blue-500 disabled:bg-gray-400 text-white px-2">選択</button>
                     </td>
                 </tr>
@@ -55,7 +56,7 @@
                     <h2 class="text-lg font-medium text-gray-900 my-4">画像を選択してください。</h2>
                     <button type="button" x-on:click="$dispatch('close')">閉じる</button>
                 </div>
-                <input type="text" name="selected-image-flag" id="selected_image_flag" class="border-none w-full" value="{{ old('selected-image-flag') ?? $chara->image->path }}" readonly>
+                <input type="text" name="selected-image-flag" id="selected_image_flag" class="border-none w-full" value="{{ old('selected-image-flag') ?? $chara->image->name }}" readonly>
                 <div id="gallery">
                     @include('gallery.view')
                 </div>

--- a/resources/views/characters/edit.blade.php
+++ b/resources/views/characters/edit.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __($chara_name. ' 編集') }}
+            {{ __($chara->name. ' 編集') }}
         </h2>
     </x-slot>
     
@@ -13,24 +13,24 @@
             @endforeach
         </ul>
         @endif
-        <form name="inputus" method="post" action="{{ route('charas.edit', ['chara' => $chara_id]) }}" enctype="multipart/form-data">
+        <form name="inputus" method="post" action="{{ route('charas.edit', ['chara' => $chara->id]) }}" enctype="multipart/form-data">
             <table class="bar w-full bg-white my-3">
                 <tr>
                     <th class="w-1/6">キャラクター名</th>
-                    <td><input type="text" name="name" value="{{ old('name') ?? $chara_name }}" class="w-4/12"></td>
+                    <td><input type="text" name="name" value="{{ old('name') ?? $chara->name }}" class="w-4/12"></td>
                 </tr>
                 <tr>
                     <th class="w-1/6">説明</th>
                     <td class="textboard">
-                        <div class="dummy_textarea" aria-hidden="true">{{ old('explain') ?? $chara_explain }}</div>
-                        <textarea type="text" name="explain" class="retextarea w-full h-full">{{ old('explain') ?? $chara_explain }}</textarea>
+                        <div class="dummy_textarea" aria-hidden="true">{{ old('explain') ?? $chara->explain }}</div>
+                        <textarea type="text" name="explain" class="retextarea w-full h-full">{{ old('explain') ?? $chara->explain }}</textarea>
                     </td>
                 </tr>
                 <tr>
                     <th class="w-1/6">もっと詳しく</th>
                     <td class="textboard">
-                        <div class="dummy_textarea" aria-hidden="true">{{ old('descript') ?? $chara_descript }}</div>
-                        <textarea type="text" name="descript" class="retextarea w-full h-full">{{ old('descript') ?? $chara_descript }}</textarea>
+                        <div class="dummy_textarea" aria-hidden="true">{{ old('descript') ?? $chara->descript }}</div>
+                        <textarea type="text" name="descript" class="retextarea w-full h-full">{{ old('descript') ?? $chara->descript }}</textarea>
                     </td>
                 </tr>
                 <tr>
@@ -39,8 +39,8 @@
                         <input type="radio" name="i-radio" value="upload">
                         <input type="file" name="uploaded_image" id="uploaded_image" accept="image/png, image/jpeg">
                         <p class="text-center">または</p>
-                        <input type="radio" name="i-radio" value="select" {{ old('$selected_image') == $chara_image ? '' : 'checked' }}>
-                        <input type="text" name="selected_image" id="selected_image" class="w-full max-w-[90%] px-0" value="{{ old('selected_image') ?? $chara_image }}" readonly>
+                        <input type="radio" name="i-radio" value="select" {{ old('$selected_image') == $chara->image ? '' : 'checked' }}>
+                        <input type="text" name="selected_image" id="selected_image" class="w-full max-w-[90%] px-0" value="{{ old('selected_image') ?? $chara->image->path }}" readonly>
                         <button type="button" id="selecter_open" x-data="" x-on:click.prevent="$dispatch('open-modal', 'image-uploader')" class="bg-blue-500 disabled:bg-gray-400 text-white px-2">選択</button>
                     </td>
                 </tr>
@@ -55,7 +55,7 @@
                     <h2 class="text-lg font-medium text-gray-900 my-4">画像を選択してください。</h2>
                     <button type="button" x-on:click="$dispatch('close')">閉じる</button>
                 </div>
-                <input type="text" name="selected-image-flag" id="selected_image_flag" class="border-none w-full" value="{{ old('selected-image-flag') ?? $chara_image }}" readonly>
+                <input type="text" name="selected-image-flag" id="selected_image_flag" class="border-none w-full" value="{{ old('selected-image-flag') ?? $chara->image->path }}" readonly>
                 <div id="gallery">
                     @include('gallery.view')
                 </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -16,8 +16,8 @@
                 <a href="{{ route('users.index', ['user' => $character->user->id]) }}" class="text-sky-800">{{ $character->user->name }}</a>
             </div>
                 <div class="flex my-4">
-                @if($character->image_path !== null)
-                <img src="{{ asset($character->image_path) }}" class="mx-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
+                @if($character->image !== null)
+                <img src="{{ asset($character->image->path) }}" class="mx-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
                 @endif
                 <p>{{$character->explain}}</p>
             </div>

--- a/resources/views/gallery/detail.blade.php
+++ b/resources/views/gallery/detail.blade.php
@@ -8,9 +8,20 @@
     </x-slot>
     
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-        <div class="py-4">
-            <div class="max-w-[50%] max-h-[50%]">
-                <img src="{{ asset($image->path) }}" class="w-full h-full bg-white">
+        <div class="py-4 flex">
+            <div class="w-full max-h-full">
+                <img src="{{ asset($image->path) }}" class="w-full relative bg-white">
+            </div>
+            <div class="px-4 sm:px-8 w-full">
+                <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                    <h2 class="text-xl">投稿者:<a href="{{ route('users.index', ['user' => $image->user]) }}" class="text-sky-800">{{ $image->user->name }}</a></h2>
+                    <h2 class="pt-4 text-xl">この画像を使用しているキャラクター</h2>
+                    @foreach($charas as $chara)
+                        <a href="{{ route('charas.detail', ['chara' => $chara->id]) }}" class="text-sky-800">
+                            {{ $chara->name }}
+                        </a>
+                    @endforeach
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/gallery/view.blade.php
+++ b/resources/views/gallery/view.blade.php
@@ -3,9 +3,9 @@
         <div class="my-4">
             <div class="flex flex-wrap -m-4 items-center">
                 @foreach($images as $image)
-                <button class="uploaded_imagen bg-white m-4 w-full max-w-44 h-full max-h-44" type="button" value="{{ $image->path }}" >
-                    <img src="{{ asset($image->path) }}" class="w-full h-full">
-                </button>
+                <div class="w-full max-w-44 h-full max-h-44 m-4">
+                    <img src="{{ asset($image->path) }}" id="{{ $image->id }}" class="uploaded_image_selector bg-white w-full h-full" alt="{{ $image->name }}">
+                </div>
                 @endforeach
             </div>
             {{ $images->render('vendor.pagination.tailwind_pagination') }}


### PR DESCRIPTION
### キャラクターデータベースの構造を変換
キャラクターデータベースのimage_pathをimage_idに変換し、idを通じてキャラに登録されたimageを参照できるようにしました。

### キャラクターページから画像ページへの直接リンクを実装
キャラ画像をクリックすることで、image_idを含むURLにアクセスできるようになりました。反対に画像ページ右側から、その画像を使用したキャラクターページへのリンクを記載しました。

【以下、4/8更新】
### 画像データIDの参照の本格化
前回、画像IDを外部キーにしてキャラクターに登録することで、IDを通じて画像データにアクセスできるようなりました。今回はその機能を発展することを主軸に、
○作成・編集時の画像選択での取得データをパスからIDに変更
○画像IDを代入した変数をセッションにわたす
○削除確認画面およびダッシュボードページの表示を修正
以上の取り組みを実施しました。