### PR TITLE
Add Link to Image

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -17,7 +17,7 @@
             </div>
                 <div class="flex my-4">
                 @if($character->image !== null)
-                <img src="{{ asset($character->image->path) }}" class="mx-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44">
+                <img src="{{ asset($character->image->path) }}" class="mx-4 ml-0 mb-0 w-full max-w-44 h-full max-h-44" onclick="location.href='{{ route('images.detail', ['image' => $character->image->id]) }}'">
                 @endif
                 <p>{{$character->explain}}</p>
             </div>


### PR DESCRIPTION
### ユーザーページ及びユーザー別画像一覧の画像から詳細ページへのリンクを実装
<img>タグにonclick属性を付与し画像詳細ページへジャンプするようにしました。
【4/18追記】
ダッシュボード画面の画像にリンクを付与しました。