### PR TITLE
ブックマークに関する画面の改修

### DIFF
--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -36,15 +36,18 @@ class CharacterController extends Controller
     
     public function detail(Character $chara){
         $chara->findOrFail($chara->id);
+        $marked = false;
         
-        $user = Auth::user();
-        $existingBookmark = Bookmark::where('character_id', $chara->id)->where('user_id', $user->id)->first();
-        
-        if ($existingBookmark){
-            $marked = true;
-        }
-        else{
-            $marked = false;
+        if (Auth::user()){
+            $user = Auth::user();
+            $existingBookmark = Bookmark::where('character_id', $chara->id)->where('user_id', $user->id)->first();
+
+            if ($existingBookmark){
+                $marked = true;
+            }
+            else{
+                $marked = false;
+            }
         }
         
         return view('characters.detail', [

--- a/resources/views/characters/create.blade.php
+++ b/resources/views/characters/create.blade.php
@@ -17,20 +17,20 @@
             <table class="bar w-full bg-white my-3">
                 <tr>
                     <th class="w-1/6">キャラクター名</th>
-                    <td><input type="text" name="name" class="w-4/12"></td>
+                    <td><input type="text" name="name" class="w-4/12" value="{{ old('name') }}"></td>
                 </tr>
                 <tr>
                     <th class="w-1/6">説明</th>
                     <td class="textboard">
                         <div class="dummy_textarea" aria-hidden="true"></div>
-                        <textarea type="text" name="explain" class="retextarea w-full h-full"></textarea>
+                        <textarea type="text" name="explain" class="retextarea w-full h-full" value="{{ old('explain') }}"></textarea>
                     </td>
                 </tr>
                 <tr>
                     <th class="w-1/6">もっと詳しく</th>
                     <td class="textboard">
                         <div class="dummy_textarea" aria-hidden="true"></div>
-                        <textarea type="text" name="descript" class="retextarea w-full h-full"></textarea>
+                        <textarea type="text" name="descript" class="retextarea w-full h-full" value="{{ old('descript') }}"></textarea>
                     </td>
                 </tr>
                 <tr>

--- a/resources/views/characters/detail.blade.php
+++ b/resources/views/characters/detail.blade.php
@@ -4,15 +4,17 @@
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
                 {{ __($chara->name. ' 詳細情報') }}
             </h2>
-            @if($chara->user->id !== Auth::user()->id)
-            <form>
-                @csrf
-                @if($marked)
-                <button type="button" href="{{ route('charas.bookmark', ['chara' => $chara->id]) }}" class="bookmark">★</button>
-                @else
-                <button type="button" href="{{ route('charas.bookmark', ['chara' => $chara->id]) }}" class="bookmark">☆</button>
+            @if(Auth::user())
+                @if($chara->user->id !== Auth::user()->id)
+                <form>
+                    @csrf
+                    @if($marked)
+                    <button type="button" href="{{ route('charas.bookmark', ['chara' => $chara->id]) }}" class="bookmark">★</button>
+                    @else
+                    <button type="button" href="{{ route('charas.bookmark', ['chara' => $chara->id]) }}" class="bookmark">☆</button>
+                    @endif
+                </form>
                 @endif
-            </form>
             @endif
         </div>
     </x-slot>

--- a/resources/views/characters/edit.blade.php
+++ b/resources/views/characters/edit.blade.php
@@ -17,19 +17,19 @@
             <table class="bar w-full bg-white my-3">
                 <tr>
                     <th class="w-1/6">キャラクター名</th>
-                    <td><input type="text" name="name" value="{{ old('name') ?? $chara->name }}" class="w-4/12"></td>
+                    <td><input type="text" name="name" value="{{ old('name', $chara->name) }}" class="w-4/12"></td>
                 </tr>
                 <tr>
                     <th class="w-1/6">説明</th>
                     <td class="textboard">
-                        <div class="dummy_textarea" aria-hidden="true">{{ old('explain') ?? $chara->explain }}</div>
+                        <div class="dummy_textarea" aria-hidden="true">{{ old('explain', $chara->explain) }}</div>
                         <textarea type="text" name="explain" class="retextarea w-full h-full">{{ old('explain') ?? $chara->explain }}</textarea>
                     </td>
                 </tr>
                 <tr>
                     <th class="w-1/6">もっと詳しく</th>
                     <td class="textboard">
-                        <div class="dummy_textarea" aria-hidden="true">{{ old('descript') ?? $chara->descript }}</div>
+                        <div class="dummy_textarea" aria-hidden="true">{{ old('descript', $chara->descript) }}</div>
                         <textarea type="text" name="descript" class="retextarea w-full h-full">{{ old('descript') ?? $chara->descript }}</textarea>
                     </td>
                 </tr>
@@ -40,8 +40,8 @@
                         <input type="file" name="uploaded_image" id="uploaded_image" accept="image/png, image/jpeg">
                         <p class="text-center">または</p>
                         <input type="radio" name="i-radio" value="select" {{ old('$selected_image') == $chara->image ? '' : 'checked' }}>
-                        <input type="hidden" name="selected_image" id="selected_image">
-                        <input type="text" name="selected_image_path" id="selected_image_path" class="w-full max-w-[90%] px-0" value="{{ old('selected_image_path') ?? $chara->image->name }}" readonly>
+                        <input type="hidden" name="selected_image" id="selected_image" value="{{ old('selected_image') == $chara->image_id ? '' : $chara->image_id }}">
+                        <input type="text" name="selected_image_path" id="selected_image_path" class="w-full max-w-[90%] px-0" value="{{ old('selected_image_path') == $chara->image ? '' : $chara->image->name }}" readonly>
                         <button type="button" id="selecter_open" x-data="" x-on:click.prevent="$dispatch('open-modal', 'image-uploader')" class="bg-blue-500 disabled:bg-gray-400 text-white px-2">選択</button>
                     </td>
                 </tr>
@@ -56,7 +56,7 @@
                     <h2 class="text-lg font-medium text-gray-900 my-4">画像を選択してください。</h2>
                     <button type="button" x-on:click="$dispatch('close')">閉じる</button>
                 </div>
-                <input type="text" name="selected-image-flag" id="selected_image_flag" class="border-none w-full" value="{{ old('selected-image-flag') ?? $chara->image->name }}" readonly>
+                <input type="text" name="selected-image-flag" id="selected_image_flag" class="border-none w-full" value="{{ old('selected-image-flag') == $chara->image ? '' : $chara->image->name }}" readonly>
                 <div id="gallery">
                     @include('gallery.view')
                 </div>

--- a/resources/views/users/bookmark.blade.php
+++ b/resources/views/users/bookmark.blade.php
@@ -12,9 +12,9 @@
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
         <div class="bg-white -mx-4 mt-4 p-4">
             @foreach($bookmarks as $bookmark)
-            <div class="flex">
-                <button type="button" href="{{ route('charas.bookmark', ['chara' => $bookmark->character->id]) }}" class="bookmark">★</button>
+            <div class="flex justify-between">
                 <a href="{{ route('charas.detail', ['chara' => $bookmark->character->id]) }}" class="text-sky-800">{{ $bookmark->character->name }}</a>
+                <button type="button" href="{{ route('charas.bookmark', ['chara' => $bookmark->character->id]) }}" class="bookmark">★</button>
             </div>
             @endforeach
         </div>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -77,10 +77,11 @@
         
         @if($bookmarks->count() !== 0)
         <h3 class="mt-4 text-lg">{{$user->name}}のブックマーク</h3>
-        <div>
+        <div class="bg-white">
             @foreach($bookmarks as $bookmark)
             <div class="flex justify-between">
                 <a href="{{ route('charas.detail', ['chara' => $bookmark->character->id]) }}" class="text-sky-800">{{ $bookmark->character->name }}</a>
+                <button type="button" href="{{ route('charas.bookmark', ['chara' => $bookmark->character->id]) }}" class="bookmark px-4">★</button>
             </div>
             @endforeach
         </div>
@@ -92,4 +93,5 @@
         @endif
     </div>
     <script src="{{ asset('/js/followSystem.js') }}"></script>
+    <script src="{{ asset('/js/bookmark.js') }}"></script>
 </x-app-layout>


### PR DESCRIPTION
### ログインしていない時にキャラクターのページがエラーになる不具合を解消
ログインユーザーのidを参照する仕様上、idを持たないゲスト状態ではキャラクターページに入れずエラーになる状態を、その処理の前に「ログインユーザーだった場合に行う」if文を記述し、ゲストユーザーには実行しない事で解消しました。

### ユーザーページのブックマーク一覧からブックマーク機能実装
ユーザーページからすぐにブックマークを管理できるよう、ブックマーク機能を実装いたしました。これに伴い、そのページ及びブックマークページの、ブックマークボタンの位置を右に変更しました。